### PR TITLE
Ability to mock Execute and ExecuteAsync.

### DIFF
--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -146,27 +146,27 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void ExecuteNonQuery()
+        public void Execute()
         {
             var connection = new Mock<IDbConnection>();
 
-            connection.SetupDapper(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
-                    .Returns(1);
+            connection.SetupDapper(c => c.Execute(It.IsAny<string>(), null, null, null, null))
+                      .Returns(1);
 
-            var result = connection.Object.Execute("Robert'); DROP TABLE Students;--");
+            var result = connection.Object.Execute("");
 
             Assert.That(result, Is.EqualTo(1));
         }
 
         [Test]
-        public async Task ExecuteNonQueryAsync()
+        public async Task ExecuteAsync()
         {
             var connection = new Mock<DbConnection>();
 
-            connection.SetupDapperAsync(c => c.ExecuteAsync("Robert'); DROP TABLE Students;--", null, null, null, null))
-                    .ReturnsAsync(1);
+            connection.SetupDapperAsync(c => c.ExecuteAsync("", null, null, null, null))
+                      .ReturnsAsync(1);
 
-            var result = await connection.Object.ExecuteAsync("Robert'); DROP TABLE Students;--");
+            var result = await connection.Object.ExecuteAsync("");
 
             Assert.That(result, Is.EqualTo(1));
 

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -28,7 +28,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public async Task QueryAsyncGeneric()
+        public void QueryAsyncGeneric()
         {
             var connection = new Mock<DbConnection>();
 
@@ -37,7 +37,7 @@ namespace Moq.Dapper.Test
             connection.SetupDapperAsync(c => c.QueryAsync<int>(It.IsAny<string>(), null, null, null, null))
                       .ReturnsAsync(expected);
 
-            var actual = (await connection.Object.QueryAsync<int>("")).ToList();
+            var actual = connection.Object.QueryAsync<int>("").GetAwaiter().GetResult().ToList();
             
             Assert.That(actual.Count, Is.EqualTo(expected.Length));
             Assert.That(actual, Is.EquivalentTo(expected));
@@ -169,8 +169,6 @@ namespace Moq.Dapper.Test
             var result = await connection.Object.ExecuteAsync("");
 
             Assert.That(result, Is.EqualTo(1));
-
-            connection.VerifyAll();
         }
 
         [Test]

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -1,4 +1,5 @@
-﻿using Dapper;
+﻿using System.Threading.Tasks;
+using Dapper;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
 using System;
@@ -27,7 +28,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void QueryAsyncGeneric()
+        public async Task QueryAsyncGeneric()
         {
             var connection = new Mock<DbConnection>();
 
@@ -36,7 +37,7 @@ namespace Moq.Dapper.Test
             connection.SetupDapperAsync(c => c.QueryAsync<int>(It.IsAny<string>(), null, null, null, null))
                       .ReturnsAsync(expected);
 
-            var actual = connection.Object.QueryAsync<int>("").GetAwaiter().GetResult().ToList();
+            var actual = (await connection.Object.QueryAsync<int>("")).ToList();
             
             Assert.That(actual.Count, Is.EqualTo(expected.Length));
             Assert.That(actual, Is.EquivalentTo(expected));
@@ -158,16 +159,18 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void ExecuteNonQueryAsync()
+        public async Task ExecuteNonQueryAsync()
         {
             var connection = new Mock<DbConnection>();
 
-            connection.SetupDapperAsync(c => c.ExecuteAsync(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+            connection.SetupDapperAsync(c => c.ExecuteAsync("Robert'); DROP TABLE Students;--", null, null, null, null))
                     .ReturnsAsync(1);
 
-            var result = connection.Object.ExecuteAsync("Robert'); DROP TABLE Students;--");
+            var result = await connection.Object.ExecuteAsync("Robert'); DROP TABLE Students;--");
 
             Assert.That(result, Is.EqualTo(1));
+
+            connection.VerifyAll();
         }
 
         [Test]

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Dapper;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using Dapper;
-using NUnit.Framework;
-using NUnit.Framework.Constraints;
 
 namespace Moq.Dapper.Test
 {
@@ -149,11 +149,25 @@ namespace Moq.Dapper.Test
         {
             var connection = new Mock<IDbConnection>();
 
-            connection.SetupDapper(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null));
+            connection.SetupDapper(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                    .Returns(1);
 
-            connection.Object.Execute("Robert'); DROP TABLE Students;--");
+            var result = connection.Object.Execute("Robert'); DROP TABLE Students;--");
 
-            connection.Verify(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null), Times.Once());
+            Assert.That(result, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ExecuteNonQueryAsync()
+        {
+            var connection = new Mock<DbConnection>();
+
+            connection.SetupDapperAsync(c => c.ExecuteAsync(It.IsAny<string>(), It.IsAny<object>(), null, null, null))
+                    .ReturnsAsync(1);
+
+            var result = connection.Object.ExecuteAsync("Robert'); DROP TABLE Students;--");
+
+            Assert.That(result, Is.EqualTo(1));
         }
 
         [Test]

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -145,6 +145,18 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
+        public void ExecuteNonQuery()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapper(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null));
+
+            connection.Object.Execute("Robert'); DROP TABLE Students;--");
+
+            connection.Verify(c => c.Execute(It.IsAny<string>(), It.IsAny<object>(), null, null, null), Times.Once());
+        }
+
+        [Test]
         public void NonDapperMethodException()
         {
             var connection = new Mock<IDbConnection>();

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -1,11 +1,11 @@
-﻿using System.Threading.Tasks;
-using Dapper;
-using NUnit.Framework;
-using NUnit.Framework.Constraints;
-using System;
+﻿using System;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace Moq.Dapper.Test
 {

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -1,10 +1,10 @@
-﻿using Dapper;
-using Moq.Language.Flow;
-using System;
+﻿using System;
 using System.Collections;
 using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
+using Dapper;
+using Moq.Language.Flow;
 
 namespace Moq.Dapper
 {

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -139,10 +139,8 @@ namespace Moq.Dapper
                      .Callback<TResult>(r => result = r);
 
             var commandMock = new Mock<IDbCommand>();
-
             commandMock.SetupGet(a => a.Parameters)
                        .Returns(new Mock<IDataParameterCollection>().Object);
-
             commandMock.Setup(a => a.CreateParameter())
                        .Returns(new Mock<IDbDataParameter>().Object);
 

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -139,8 +139,10 @@ namespace Moq.Dapper
                      .Callback<TResult>(r => result = r);
 
             var commandMock = new Mock<IDbCommand>();
+            
             commandMock.SetupGet(a => a.Parameters)
                        .Returns(new Mock<IDataParameterCollection>().Object);
+
             commandMock.Setup(a => a.CreateParameter())
                        .Returns(new Mock<IDbDataParameter>().Object);
 


### PR DESCRIPTION
Hey there!

Some co-workers found your library and thought that it would be cool if it supported mocking `Execute` and `ExecuteAsync`. 

So I thought I would take a stab at adding support for those two methods. 

I'm not 100% satisfied with the result here as I don't seem to be able to control which result is returned based on the initial mock setup. Maybe you could point in the right direction?

Thanks!

Tom