### PR TITLE
Implements SetupDapperAsync for IDbConnection.

### DIFF
--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -50,7 +50,7 @@ namespace Moq.Dapper.Test
             var expected = new[] { 7, 77, 777 };
 
             connection.SetupDapperAsync(c => c.QueryAsync<int>(It.IsAny<string>(), null, null, null, null))
-                .ReturnsAsync(expected);
+                      .ReturnsAsync(expected);
 
             var actual = connection.Object.QueryAsync<int>("").GetAwaiter().GetResult().ToList();
 

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -43,6 +43,22 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
+        public void QueryAsyncGenericUsingDbConnectionInterface()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            var expected = new[] { 7, 77, 777 };
+
+            connection.SetupDapperAsync(c => c.QueryAsync<int>(It.IsAny<string>(), null, null, null, null))
+                .ReturnsAsync(expected);
+
+            var actual = connection.Object.QueryAsync<int>("").GetAwaiter().GetResult().ToList();
+
+            Assert.That(actual.Count, Is.EqualTo(expected.Length));
+            Assert.That(actual, Is.EquivalentTo(expected));
+        }
+
+        [Test]
         public void QueryGeneric()
         {
             var connection = new Mock<IDbConnection>();

--- a/Moq.Dapper/DbCommandSetup.cs
+++ b/Moq.Dapper/DbCommandSetup.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Moq.Language.Flow;
+using Moq.Protected;
+
+namespace Moq.Dapper
+{
+    public static class DbCommandSetup
+    {
+        internal static ISetup<TConnection, Task<TResult>> SetupCommandAsync<TResult, TConnection>(Mock<TConnection> mock, Action<Mock<DbCommand>, Func<TResult>> mockResult)
+            where TConnection : class, IDbConnection
+        {
+            var setupMock = new Mock<ISetup<TConnection, Task<TResult>>>();
+
+            var result = default(TResult);
+
+            setupMock.Setup(setup => setup.Returns(It.IsAny<Func<Task<TResult>>>()))
+                     .Callback<Func<Task<TResult>>>(r => result = r().Result);
+
+            var commandMock = new Mock<DbCommand>();
+
+            commandMock.Protected()
+                       .SetupGet<DbParameterCollection>("DbParameterCollection")
+                       .Returns(new Mock<DbParameterCollection>().Object);
+
+            commandMock.Protected()
+                       .Setup<DbParameter>("CreateDbParameter")
+                       .Returns(new Mock<DbParameter>().Object);
+
+            mockResult(commandMock, () => result);
+
+            var iDbConnectionMock = mock.As<IDbConnection>();
+
+            iDbConnectionMock.Setup(m => m.CreateCommand())
+                             .Returns(commandMock.Object);
+
+            iDbConnectionMock.SetupGet(m => m.State)
+                             .Returns(ConnectionState.Open);
+
+            if (typeof(TConnection) == typeof(DbConnection))
+                mock.Protected()
+                    .Setup<DbCommand>("CreateDbCommand")
+                    .Returns(commandMock.Object);
+
+            return setupMock.Object;
+        }
+    }
+}

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -55,7 +55,7 @@ namespace Moq.Dapper
             {
                 commandMock.Protected()
                            .Setup<Task<DbDataReader>>("ExecuteDbDataReaderAsync", ItExpr.IsAny<CommandBehavior>(), ItExpr.IsAny<CancellationToken>())
-                           .ReturnsAsync(() => DbConnectionMockExtensions.DbDataReader(result));
+                           .ReturnsAsync(() => DbDataReaderFactory.DbDataReader(result));
             });
 
         private static ISetup<IDbConnection, Task<TResult>> SetupCommandAsync<TResult>(Mock<IDbConnection> mock, Action<Mock<DbCommand>, Func<TResult>> mockResult)

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -54,8 +54,8 @@ namespace Moq.Dapper
             SetupCommandAsync<TResult>(mock, (commandMock, result) =>
             {
                 commandMock.Protected()
-                    .Setup<Task<DbDataReader>>("ExecuteDbDataReaderAsync", ItExpr.IsAny<CommandBehavior>(), ItExpr.IsAny<CancellationToken>())
-                    .ReturnsAsync(() => DbConnectionMockExtensions.DbDataReader(result));
+                           .Setup<Task<DbDataReader>>("ExecuteDbDataReaderAsync", ItExpr.IsAny<CommandBehavior>(), ItExpr.IsAny<CancellationToken>())
+                           .ReturnsAsync(() => DbConnectionMockExtensions.DbDataReader(result));
             });
 
         private static ISetup<IDbConnection, Task<TResult>> SetupCommandAsync<TResult>(Mock<IDbConnection> mock, Action<Mock<DbCommand>, Func<TResult>> mockResult)
@@ -65,21 +65,24 @@ namespace Moq.Dapper
             var result = default(TResult);
 
             setupMock.Setup(setup => setup.Returns(It.IsAny<Func<Task<TResult>>>()))
-                .Callback<Func<Task<TResult>>>(r => result = r().Result);
+                     .Callback<Func<Task<TResult>>>(r => result = r().Result);
 
             var commandMock = new Mock<DbCommand>();
 
             commandMock.Protected()
-                .SetupGet<DbParameterCollection>("DbParameterCollection")
-                .Returns(new Mock<DbParameterCollection>().Object);
+                       .SetupGet<DbParameterCollection>("DbParameterCollection")
+                       .Returns(new Mock<DbParameterCollection>().Object);
 
             commandMock.Protected()
-                .Setup<DbParameter>("CreateDbParameter")
-                .Returns(new Mock<DbParameter>().Object);
+                       .Setup<DbParameter>("CreateDbParameter")
+                       .Returns(new Mock<DbParameter>().Object);
 
             mockResult(commandMock, () => result);
 
-            mock.As<IDbConnection>().SetupGet(x => x.State).Returns(ConnectionState.Open);
+            mock.As<IDbConnection>()
+                .SetupGet(x => x.State)
+                .Returns(ConnectionState.Open);
+
             mock.As<IDbConnection>()
                 .Setup(m => m.CreateCommand())
                 .Returns(commandMock.Object);

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -34,7 +34,7 @@ namespace Moq.Dapper
             }
         }
 
-        public static ISetup<IDbConnection, Task<TResult>> SetupDapperAsync<TResult>(this Mock<IDbConnection> mock, Expression<Func<DbConnection, Task<TResult>>> expression)
+        public static ISetup<IDbConnection, Task<TResult>> SetupDapperAsync<TResult>(this Mock<IDbConnection> mock, Expression<Func<IDbConnection, Task<TResult>>> expression)
         {
             var call = expression.Body as MethodCallExpression;
 

--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -49,54 +49,8 @@ namespace Moq.Dapper
             {
                 commandMock.Protected()
                            .Setup<Task<DbDataReader>>("ExecuteDbDataReaderAsync", ItExpr.IsAny<CommandBehavior>(), ItExpr.IsAny<CancellationToken>())
-                           .ReturnsAsync(() => DbDataReader(result));
+                           .ReturnsAsync(() => DbDataReaderFactory.DbDataReader(result));
             });
-
-        internal static DbDataReader DbDataReader<TResult>(Func<TResult> result)
-        {
-            // TResult must be IEnumerable if we're invoking SqlMapper.Query.
-            var enumerable = (IEnumerable) result();
-
-            var dataTable = new DataTable();
-
-            // Assuming SqlMapper.Query returns always generic IEnumerable<TResult>.
-            var type = typeof(TResult).GenericTypeArguments.First();
-
-            if (type.IsPrimitive || type == typeof(string))
-            {
-                dataTable.Columns.Add();
-
-                foreach (var element in enumerable)
-                    dataTable.Rows.Add(element);
-            }
-            else
-            {
-                var properties =
-                        type.GetProperties().
-                             Where
-                             (
-                              info => info.CanRead &&
-                                      (info.PropertyType.IsPrimitive ||
-                                       info.PropertyType == typeof(DateTime) ||
-                                       info.PropertyType == typeof(DateTimeOffset) ||
-                                       info.PropertyType == typeof(decimal) ||
-                                       info.PropertyType == typeof(Guid) ||
-                                       info.PropertyType == typeof(string) ||
-                                       info.PropertyType == typeof(TimeSpan))).
-                             ToList();
-
-                var columns = properties.Select(property => new DataColumn(property.Name, property.PropertyType)).ToArray();
-
-                dataTable.Columns.AddRange(columns);
-
-                var valuesFactory = properties.Select(info => (Func<object, object>) info.GetValue).ToArray();
-
-                foreach (var element in enumerable)
-                    dataTable.Rows.Add(valuesFactory.Select(getValue => getValue(element)).ToArray());
-            }
-
-            return new DataTableReader(dataTable);
-        }
 
         private static ISetup<DbConnection, Task<TResult>> SetupCommandAsync<TResult>(Mock<DbConnection> mock, Action<Mock<DbCommand>, Func<TResult>> mockResult)
         {

--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -19,7 +19,7 @@ namespace Moq.Dapper
             var call = expression.Body as MethodCallExpression;
 
             if (call?.Method.DeclaringType != typeof(SqlMapper))
-                throw new ArgumentException("Not a Dapper mehtod.");
+                throw new ArgumentException("Not a Dapper method.");
 
             switch (call.Method.Name)
             {
@@ -33,7 +33,7 @@ namespace Moq.Dapper
             var call = expression.Body as MethodCallExpression;
 
             if (call?.Method.DeclaringType != typeof(SqlMapper))
-                throw new ArgumentException("Not a Dapper mehtod.");
+                throw new ArgumentException("Not a Dapper method.");
 
             switch (call.Method.Name)
             {
@@ -52,7 +52,7 @@ namespace Moq.Dapper
                            .ReturnsAsync(() => DbDataReader(result));
             });
 
-        private static DbDataReader DbDataReader<TResult>(Func<TResult> result)
+        internal static DbDataReader DbDataReader<TResult>(Func<TResult> result)
         {
             // TResult must be IEnumerable if we're invoking SqlMapper.Query.
             var enumerable = (IEnumerable) result();

--- a/Moq.Dapper/DbDataReaderFactory.cs
+++ b/Moq.Dapper/DbDataReaderFactory.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+
+namespace Moq.Dapper
+{
+    internal static class DbDataReaderFactory
+    {
+        internal static DbDataReader DbDataReader<TResult>(Func<TResult> result)
+        {
+            // TResult must be IEnumerable if we're invoking SqlMapper.Query.
+            var enumerable = (IEnumerable)result();
+
+            var dataTable = new DataTable();
+
+            // Assuming SqlMapper.Query returns always generic IEnumerable<TResult>.
+            var type = typeof(TResult).GenericTypeArguments.First();
+
+            if (type.IsPrimitive || type == typeof(string))
+            {
+                dataTable.Columns.Add();
+
+                foreach (var element in enumerable)
+                    dataTable.Rows.Add(element);
+            }
+            else
+            {
+                var properties =
+                    type.GetProperties()
+                        .Where(info => info.CanRead &&
+                                      (info.PropertyType.IsPrimitive ||
+                                       info.PropertyType == typeof(DateTime) ||
+                                       info.PropertyType == typeof(DateTimeOffset) ||
+                                       info.PropertyType == typeof(decimal) ||
+                                       info.PropertyType == typeof(Guid) ||
+                                       info.PropertyType == typeof(string) ||
+                                       info.PropertyType == typeof(TimeSpan)))
+                        .ToList();
+
+                var columns = properties.Select(property => new DataColumn(property.Name, property.PropertyType)).ToArray();
+
+                dataTable.Columns.AddRange(columns);
+
+                var valuesFactory = properties.Select(info => (Func<object, object>)info.GetValue).ToArray();
+
+                foreach (var element in enumerable)
+                    dataTable.Rows.Add(valuesFactory.Select(getValue => getValue(element)).ToArray());
+            }
+
+            return new DataTableReader(dataTable);
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements SetupDapperAsync for IDbConnection, previously we could only test Dapper async methods mocking a DbConnection.

I look forward for your feedback on this.