### PR TITLE
Adding byte array support for binary data types

### DIFF
--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -127,10 +127,7 @@ namespace Moq.Dapper.Test
                                                co.DateTimeProperty == complexObject.DateTimeProperty &&
                                                co.NullableIntegerProperty == complexObject.NullableIntegerProperty &&
                                                co.NullableDateTimeProperty == complexObject.NullableDateTimeProperty &&
-                                               (
-                                                co.ByteArrayPropery == null && complexObject.ByteArrayPropery == null ||
-                                                co.ByteArrayPropery.Equals(complexObject.ByteArrayPropery)
-                                               ));
+                                               co.ByteArrayPropery == complexObject.ByteArrayPropery);
 
                 Assert.That(match.Count, Is.EqualTo(1));
             }

--- a/Moq.Dapper.Test/DapperTest.cs
+++ b/Moq.Dapper.Test/DapperTest.cs
@@ -88,7 +88,8 @@ namespace Moq.Dapper.Test
                     GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
                     DateTimeProperty = new DateTime(2000, 1, 1),
                     NullableDateTimeProperty = new DateTime(2000, 1, 1),
-                    NullableIntegerProperty = 9
+                    NullableIntegerProperty = 9,
+                    ByteArrayPropery = new byte[] { 1, 2, 4, 8 }
                 },
                 new ComplexType
                 {
@@ -97,7 +98,8 @@ namespace Moq.Dapper.Test
                     GuidProperty = Guid.Parse("FBECE122-6E2E-4791-B781-C30843DFE343"),
                     DateTimeProperty = new DateTime(2000, 1, 2),
                     NullableDateTimeProperty = new DateTime(2000, 1, 2),
-                    NullableIntegerProperty = 99
+                    NullableIntegerProperty = 99,
+                    ByteArrayPropery = new byte[] { 1, 3, 5, 7 }
                 },
                 new ComplexType
                 {
@@ -124,7 +126,11 @@ namespace Moq.Dapper.Test
                                                co.GuidProperty == complexObject.GuidProperty &&
                                                co.DateTimeProperty == complexObject.DateTimeProperty &&
                                                co.NullableIntegerProperty == complexObject.NullableIntegerProperty &&
-                                               co.NullableDateTimeProperty == complexObject.NullableDateTimeProperty);
+                                               co.NullableDateTimeProperty == complexObject.NullableDateTimeProperty &&
+                                               (
+                                                co.ByteArrayPropery == null && complexObject.ByteArrayPropery == null ||
+                                                co.ByteArrayPropery.Equals(complexObject.ByteArrayPropery)
+                                               ));
 
                 Assert.That(match.Count, Is.EqualTo(1));
             }
@@ -179,6 +185,7 @@ namespace Moq.Dapper.Test
             public DateTime DateTimeProperty { get; set; }
             public DateTime? NullableDateTimeProperty { get; set; }
             public int? NullableIntegerProperty { get; set; }
+            public byte[] ByteArrayPropery { get; set; }
         }
     }
 }

--- a/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionInterfaceMockExtensions.cs
@@ -100,7 +100,8 @@ namespace Moq.Dapper
                                        t == typeof(decimal) ||
                                        t == typeof(Guid) ||
                                        t == typeof(string) ||
-                                       t == typeof(TimeSpan);
+                                       t == typeof(TimeSpan) ||
+                                       t == typeof(byte[]);
                                    
                                    var properties = 
                                        type.GetProperties()

--- a/Moq.Dapper/DbDataReaderFactory.cs
+++ b/Moq.Dapper/DbDataReaderFactory.cs
@@ -36,7 +36,8 @@ namespace Moq.Dapper
                                        info.PropertyType == typeof(decimal) ||
                                        info.PropertyType == typeof(Guid) ||
                                        info.PropertyType == typeof(string) ||
-                                       info.PropertyType == typeof(TimeSpan)))
+                                       info.PropertyType == typeof(TimeSpan) ||
+                                       info.PropertyType == typeof(byte[])))
                         .ToList();
 
                 var columns = properties.Select(property => new DataColumn(property.Name, property.PropertyType)).ToArray();


### PR DESCRIPTION
Added support for `byte[]` to allow mocking of data readers returning binary data. #17