### PR TITLE
Fixes for #36 and #37

### DIFF
--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -2,6 +2,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Numerics;
 using Dapper;
 using NUnit.Framework;
 
@@ -53,6 +54,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String1",
                     IntegerProperty = 7,
+                    LongProperty = 70,
+                    BigIntegerProperty = 700,
                     GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
                     DateTimeProperty = new DateTime(2000, 1, 1),
                     NullableDateTimeProperty = new DateTime(2000, 1, 1),
@@ -63,6 +66,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String2",
                     IntegerProperty = 77,
+                    LongProperty = 770,
+                    BigIntegerProperty = 7700,
                     GuidProperty = Guid.Parse("FBECE122-6E2E-4791-B781-C30843DFE343"),
                     DateTimeProperty = new DateTime(2000, 1, 2),
                     NullableDateTimeProperty = new DateTime(2000, 1, 2),
@@ -73,6 +78,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String3",
                     IntegerProperty = 777,
+                    LongProperty = 7770,
+                    BigIntegerProperty = 77700,
                     GuidProperty = Guid.Parse("712B6DA1-71D8-4D60-8FEF-3F4800A6B04F"),
                     DateTimeProperty = new DateTime(2000, 1, 3),
                     NullableDateTimeProperty = null,
@@ -96,6 +103,8 @@ namespace Moq.Dapper.Test
             {
                 var match = actual.Where(co => co.StringProperty == complexObject.StringProperty &&
                                                co.IntegerProperty == complexObject.IntegerProperty &&
+                                               co.LongProperty == complexObject.LongProperty &&
+                                               co.BigIntegerProperty == complexObject.BigIntegerProperty &&
                                                co.GuidProperty == complexObject.GuidProperty &&
                                                co.DateTimeProperty == complexObject.DateTimeProperty &&
                                                co.NullableIntegerProperty == complexObject.NullableIntegerProperty &&
@@ -108,6 +117,8 @@ namespace Moq.Dapper.Test
 
         public class ComplexType
         {
+            public BigInteger BigIntegerProperty { get; set; }
+            public long LongProperty { get; set; }
             public int IntegerProperty { get; set; }
             public string StringProperty { get; set; }
             public Guid GuidProperty { get; set; }

--- a/Moq.Dapper.Test/DapperQueryTest.cs
+++ b/Moq.Dapper.Test/DapperQueryTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Linq;
+using System.Numerics;
 using Dapper;
 using NUnit.Framework;
 
@@ -51,6 +52,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String1",
                     IntegerProperty = 7,
+                    LongProperty = 70,
+                    BigIntegerProperty = 700,
                     GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
                     DateTimeProperty = new DateTime(2000, 1, 1),
                     NullableDateTimeProperty = new DateTime(2000, 1, 1),
@@ -61,6 +64,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String2",
                     IntegerProperty = 77,
+                    LongProperty = 770,
+                    BigIntegerProperty = 7700,
                     GuidProperty = Guid.Parse("FBECE122-6E2E-4791-B781-C30843DFE343"),
                     DateTimeProperty = new DateTime(2000, 1, 2),
                     NullableDateTimeProperty = new DateTime(2000, 1, 2),
@@ -71,6 +76,8 @@ namespace Moq.Dapper.Test
                 {
                     StringProperty = "String3",
                     IntegerProperty = 777,
+                    LongProperty = 7770,
+                    BigIntegerProperty = 77700,
                     GuidProperty = Guid.Parse("712B6DA1-71D8-4D60-8FEF-3F4800A6B04F"),
                     DateTimeProperty = new DateTime(2000, 1, 3),
                     NullableDateTimeProperty = null,
@@ -89,6 +96,8 @@ namespace Moq.Dapper.Test
             {
                 var match = actual.Where(co => co.StringProperty == complexObject.StringProperty &&
                                                co.IntegerProperty == complexObject.IntegerProperty &&
+                                               co.LongProperty == complexObject.LongProperty &&
+                                               co.BigIntegerProperty == complexObject.BigIntegerProperty &&
                                                co.GuidProperty == complexObject.GuidProperty &&
                                                co.DateTimeProperty == complexObject.DateTimeProperty &&
                                                co.NullableIntegerProperty == complexObject.NullableIntegerProperty &&
@@ -102,6 +111,8 @@ namespace Moq.Dapper.Test
         public class ComplexType
         {
             public int IntegerProperty { get; set; }
+            public long LongProperty { get; set; }
+            public BigInteger BigIntegerProperty { get; set; }
             public string StringProperty { get; set; }
             public Guid GuidProperty { get; set; }
             public DateTime DateTimeProperty { get; set; }

--- a/Moq.Dapper/DbCommandSetup.cs
+++ b/Moq.Dapper/DbCommandSetup.cs
@@ -21,6 +21,8 @@ namespace Moq.Dapper
 
             var commandMock = new Mock<DbCommand>();
 
+            commandMock.SetupAllProperties();
+
             commandMock.Protected()
                        .SetupGet<DbParameterCollection>("DbParameterCollection")
                        .Returns(new Mock<DbParameterCollection>().Object);

--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -56,6 +56,8 @@ namespace Moq.Dapper
                      .Callback<Func<Task<int>>>(r => result = r().Result);
 
             var commandMock = new Mock<DbCommand>();
+
+            commandMock.SetupAllProperties();
             
             commandMock.Protected()
                        .SetupGet<DbParameterCollection>("DbParameterCollection")

--- a/Moq.Dapper/DbDataReaderFactory.cs
+++ b/Moq.Dapper/DbDataReaderFactory.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Numerics;
 
 namespace Moq.Dapper
 {
@@ -41,6 +42,7 @@ namespace Moq.Dapper
                     t == typeof(DateTime) ||
                     t == typeof(DateTimeOffset) ||
                     t == typeof(decimal) ||
+                    t == typeof(BigInteger) ||
                     t == typeof(Guid) ||
                     t == typeof(string) ||
                     t == typeof(TimeSpan) ||

--- a/Moq.Dapper/EnumerableExtensions.cs
+++ b/Moq.Dapper/EnumerableExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Data;
 using System.Linq;
+using System.Numerics;
 
 namespace Moq.Dapper
 {
@@ -34,6 +35,7 @@ namespace Moq.Dapper
                     t == typeof(DateTime) ||
                     t == typeof(DateTimeOffset) ||
                     t == typeof(decimal) ||
+                    t == typeof(BigInteger) ||
                     t == typeof(Guid) ||
                     t == typeof(string) ||
                     t == typeof(TimeSpan) ||


### PR DESCRIPTION
Fixes #36 with multi parameter invocation by persisting DbCommand mock properties
Fixes #37 by adding support for BigInteger properties (and long)

Visual Studio 2019 reformatted some files with inconsistent tabs, thus some of the larger changes to files.