### PR TITLE
Make SetupExecuteScalarAsync strongly typed

### DIFF
--- a/Moq.Dapper.Test/DapperExecuteScalarAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperExecuteScalarAsyncTest.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Data.Common;
 using Dapper;
 using NUnit.Framework;
@@ -19,6 +20,24 @@ namespace Moq.Dapper.Test
 
             var actual = connection.Object
                                    .ExecuteScalarAsync<object>("")
+                                   .GetAwaiter()
+                                   .GetResult();
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ExecuteScalarAsyncGenericWithSpecificType()
+        {
+            var connection = new Mock<DbConnection>();
+
+            const string expected = "Hello";
+
+            connection.SetupDapperAsync(c => c.ExecuteScalarAsync<string>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync(expected);
+
+            var actual = connection.Object
+                                   .ExecuteScalarAsync<string>("")
                                    .GetAwaiter()
                                    .GetResult();
 

--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -26,7 +26,7 @@ namespace Moq.Dapper
                 case nameof(SqlMapper.ExecuteAsync) when typeof(TResult) == typeof(int):
                     return (ISetup<DbConnection, Task<TResult>>)SetupExecuteAsync(mock);
                 case nameof(SqlMapper.ExecuteScalarAsync):
-                    return (ISetup<DbConnection, Task<TResult>>)SetupExecuteScalarAsync(mock);
+                    return SetupExecuteScalarAsync<TResult>(mock);
                 default:
                     throw new NotSupportedException();
             }
@@ -76,14 +76,14 @@ namespace Moq.Dapper
             return setupMock.Object;
         }
 
-        static ISetup<DbConnection, Task<object>> SetupExecuteScalarCommandAsync(Mock<DbConnection> mock, Action<Mock<DbCommand>, Func<object>> mockResult)
+        static ISetup<DbConnection, Task<TResult>> SetupExecuteScalarCommandAsync<TResult>(Mock<DbConnection> mock, Action<Mock<DbCommand>, Func<object>> mockResult)
         {
-            var setupMock = new Mock<ISetup<DbConnection, Task<object>>>();
+            var setupMock = new Mock<ISetup<DbConnection, Task<TResult>>>();
 
-            var result = default(object);
+            var result = default(TResult);
 
-            setupMock.Setup(setup => setup.Returns(It.IsAny<Func<Task<object>>>()))
-                     .Callback<Func<Task<object>>>(r => result = r().Result);
+            setupMock.Setup(setup => setup.Returns(It.IsAny<Func<Task<TResult>>>()))
+                     .Callback<Func<Task<TResult>>>(r => result = r().Result);
 
             var commandMock = new Mock<DbCommand>();
 
@@ -104,8 +104,8 @@ namespace Moq.Dapper
             return setupMock.Object;
         }
 
-        static ISetup<DbConnection, Task<object>> SetupExecuteScalarAsync(Mock<DbConnection> mock) =>
-            SetupExecuteScalarCommandAsync(mock, (commandMock, result) =>
+        static ISetup<DbConnection, Task<TResult>> SetupExecuteScalarAsync<TResult>(Mock<DbConnection> mock) =>
+            SetupExecuteScalarCommandAsync<TResult>(mock, (commandMock, result) =>
             {
                 commandMock.Setup(x => x.ExecuteScalarAsync(It.IsAny<CancellationToken>())).ReturnsAsync(result);
             });


### PR DESCRIPTION
SetupExecuteScalarAsync specific type support in generic parameter (see ExecuteScalarAsyncGenericWithSpecificType test).