### PR TITLE
Split SetupDapperAsync and remove casting

### DIFF
--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -32,6 +32,22 @@ namespace Moq.Dapper
             }
         }
 
+        public static ISetup<DbConnection, Task<int>> SetupDapperAsync(this Mock<DbConnection> mock, Expression<Func<DbConnection, Task<int>>> expression)
+        {
+            var call = expression.Body as MethodCallExpression;
+
+            if (call?.Method.DeclaringType != typeof(SqlMapper))
+                throw new ArgumentException("Not a Dapper method.");
+
+            switch (call.Method.Name)
+            {
+                case nameof(SqlMapper.ExecuteAsync):
+                    return SetupExecuteAsync(mock);
+                default:
+                    return SetupDapperAsync<int>(mock, expression);
+            }
+        }
+
         static ISetup<DbConnection, Task<TResult>> SetupQueryAsync<TResult>(Mock<DbConnection> mock) =>
             DbCommandSetup.SetupCommandAsync<TResult, DbConnection>(mock, (commandMock, result) =>
             {

--- a/Moq.Dapper/DbConnectionMockExtensions.cs
+++ b/Moq.Dapper/DbConnectionMockExtensions.cs
@@ -23,8 +23,6 @@ namespace Moq.Dapper
             {
                 case nameof(SqlMapper.QueryAsync):
                     return SetupQueryAsync<TResult>(mock);
-                case nameof(SqlMapper.ExecuteAsync) when typeof(TResult) == typeof(int):
-                    return (ISetup<DbConnection, Task<TResult>>)SetupExecuteAsync(mock);
                 case nameof(SqlMapper.ExecuteScalarAsync):
                     return (ISetup<DbConnection, Task<TResult>>)SetupExecuteScalarAsync(mock);
                 default:


### PR DESCRIPTION
Make specific SetupDapperAsync function with Task<int> return value and split SetupDapperAsync's switch.