### PR TITLE
Add support for null values and strings to First/SingleOrDefault returns

### DIFF
--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -240,6 +240,94 @@ namespace Moq.Dapper.Test
             }
         }
 
+        [Test]
+        public void QuerySingleOrDefaultWithComplexType()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            var expected = new ComplexType
+            {
+                StringProperty = "String1",
+                IntegerProperty = 7,
+                LongProperty = 70,
+                BigIntegerProperty = 700,
+                GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
+                DateTimeProperty = new DateTime(2000, 1, 1),
+                NullableDateTimeProperty = new DateTime(2000, 1, 1),
+                NullableIntegerProperty = 9,
+                ByteArrayPropery = new byte[] { 1, 2, 4, 8 },
+                EnumProperty = ComplexType.EnumType.First
+            };
+
+            connection.SetupDapperAsync(c => c.QuerySingleOrDefaultAsync<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync(expected);
+
+            var actual = connection.Object.QuerySingleOrDefaultAsync<ComplexType>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual.StringProperty, Is.EqualTo(expected.StringProperty));
+        }
+
+        [Test]
+        public void QuerySingleOrDefaultWithComplexTypeAsNull()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapperAsync(c => c.QuerySingleOrDefaultAsync<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync((ComplexType)null);
+
+            var actual = connection.Object.QuerySingleOrDefaultAsync<ComplexType>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void QueryFirstOrDefaultWithComplexType()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            var expected = new ComplexType
+            {
+                StringProperty = "String1",
+                IntegerProperty = 7,
+                LongProperty = 70,
+                BigIntegerProperty = 700,
+                GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
+                DateTimeProperty = new DateTime(2000, 1, 1),
+                NullableDateTimeProperty = new DateTime(2000, 1, 1),
+                NullableIntegerProperty = 9,
+                ByteArrayPropery = new byte[] { 1, 2, 4, 8 },
+                EnumProperty = ComplexType.EnumType.First
+            };
+
+            connection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync(expected);
+
+            var actual = connection.Object.QueryFirstOrDefaultAsync<ComplexType>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual.StringProperty, Is.EqualTo(expected.StringProperty));
+        }
+
+        [Test]
+        public void QueryFirstOrDefaultWithComplexTypeAsNull()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync((ComplexType)null);
+
+            var actual = connection.Object.QueryFirstOrDefaultAsync<ComplexType>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual, Is.Null);
+        }
+
         public class ComplexType
         {
             public enum EnumType

--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -241,7 +241,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void QuerySingleOrDefaultWithComplexType()
+        public void QuerySingleOrDefaultAsyncWithComplexType()
         {
             var connection = new Mock<IDbConnection>();
 
@@ -270,7 +270,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void QuerySingleOrDefaultWithComplexTypeAsNull()
+        public void QuerySingleOrDefaultAsyncWithComplexTypeAsNull()
         {
             var connection = new Mock<IDbConnection>();
 
@@ -285,7 +285,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void QueryFirstOrDefaultWithComplexType()
+        public void QueryFirstOrDefaultAsyncWithComplexType()
         {
             var connection = new Mock<IDbConnection>();
 
@@ -314,7 +314,7 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
-        public void QueryFirstOrDefaultWithComplexTypeAsNull()
+        public void QueryFirstOrDefaultAsyncWithComplexTypeAsNull()
         {
             var connection = new Mock<IDbConnection>();
 
@@ -322,6 +322,36 @@ namespace Moq.Dapper.Test
                       .ReturnsAsync((ComplexType)null);
 
             var actual = connection.Object.QueryFirstOrDefaultAsync<ComplexType>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void QuerySingleOrDefaultAsyncString()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<string>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync((string)null);
+
+            var actual = connection.Object.QueryFirstOrDefaultAsync<string>("")
+                                          .GetAwaiter()
+                                          .GetResult();
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void QueryFirstOrDefaultAsyncString()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapperAsync(c => c.QueryFirstOrDefaultAsync<string>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync((string)null);
+
+            var actual = connection.Object.QueryFirstOrDefaultAsync<string>("")
                                           .GetAwaiter()
                                           .GetResult();
 

--- a/Moq.Dapper.Test/DapperQueryTest.cs
+++ b/Moq.Dapper.Test/DapperQueryTest.cs
@@ -240,6 +240,32 @@ namespace Moq.Dapper.Test
             Assert.That(actual, Is.Null);
         }
 
+        [Test]
+        public void QuerySingleOrDefaultString()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapper(c => c.QueryFirstOrDefault<string>(It.IsAny<string>(), null, null, null, null))
+                      .Returns((string)null);
+
+            var actual = connection.Object.QueryFirstOrDefault<string>("");
+
+            Assert.That(actual, Is.Null);
+        }
+
+        [Test]
+        public void QueryFirstOrDefaultString()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapper(c => c.QueryFirstOrDefault<string>(It.IsAny<string>(), null, null, null, null))
+                      .Returns((string)null);
+
+            var actual = connection.Object.QueryFirstOrDefault<string>("");
+
+            Assert.That(actual, Is.Null);
+        }
+
         public class ComplexType
         {
             public enum EnumType

--- a/Moq.Dapper.Test/DapperQueryTest.cs
+++ b/Moq.Dapper.Test/DapperQueryTest.cs
@@ -200,6 +200,46 @@ namespace Moq.Dapper.Test
             Assert.That(actual, Is.Null);
         }
 
+        [Test]
+        public void QueryFirstOrDefaultWithComplexType()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            var expected = new ComplexType
+            {
+                StringProperty = "String1",
+                IntegerProperty = 7,
+                LongProperty = 70,
+                BigIntegerProperty = 700,
+                GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
+                DateTimeProperty = new DateTime(2000, 1, 1),
+                NullableDateTimeProperty = new DateTime(2000, 1, 1),
+                NullableIntegerProperty = 9,
+                ByteArrayPropery = new byte[] { 1, 2, 4, 8 },
+                EnumProperty = ComplexType.EnumType.First
+            };
+
+            connection.SetupDapper(c => c.QueryFirstOrDefault<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .Returns(expected);
+
+            var actual = connection.Object.QueryFirstOrDefault<ComplexType>("");
+
+            Assert.That(actual.StringProperty, Is.EqualTo(expected.StringProperty));
+        }
+
+        [Test]
+        public void QueryFirstOrDefaultWithComplexTypeAsNull()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapper(c => c.QueryFirstOrDefault<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .Returns((ComplexType)null);
+
+            var actual = connection.Object.QueryFirstOrDefault<ComplexType>("");
+
+            Assert.That(actual, Is.Null);
+        }
+
         public class ComplexType
         {
             public enum EnumType

--- a/Moq.Dapper.Test/DapperQueryTest.cs
+++ b/Moq.Dapper.Test/DapperQueryTest.cs
@@ -57,6 +57,8 @@ namespace Moq.Dapper.Test
             Assert.That(actual, Is.EqualTo(expected));
         }
 
+
+
         [Test]
         public void QueryFirst()
         {
@@ -156,6 +158,46 @@ namespace Moq.Dapper.Test
 
                 Assert.That(match.Count, Is.EqualTo(1));
             }
+        }
+
+        [Test]
+        public void QuerySingleOrDefaultWithComplexType()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            var expected = new ComplexType
+            {
+                StringProperty = "String1",
+                IntegerProperty = 7,
+                LongProperty = 70,
+                BigIntegerProperty = 700,
+                GuidProperty = Guid.Parse("CF01F32D-A55B-4C4A-9B33-AAC1C20A85BB"),
+                DateTimeProperty = new DateTime(2000, 1, 1),
+                NullableDateTimeProperty = new DateTime(2000, 1, 1),
+                NullableIntegerProperty = 9,
+                ByteArrayPropery = new byte[] { 1, 2, 4, 8 },
+                EnumProperty = ComplexType.EnumType.First
+            };
+
+            connection.SetupDapper(c => c.QuerySingleOrDefault<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .Returns(expected);
+
+            var actual = connection.Object.QuerySingleOrDefault<ComplexType>("");
+
+            Assert.That(actual.StringProperty, Is.EqualTo(expected.StringProperty));
+        }
+
+        [Test]
+        public void QuerySingleOrDefaultWithComplexTypeAsNull()
+        {
+            var connection = new Mock<IDbConnection>();
+
+            connection.SetupDapper(c => c.QuerySingleOrDefault<ComplexType>(It.IsAny<string>(), null, null, null, null))
+                      .Returns((ComplexType)null);
+
+            var actual = connection.Object.QuerySingleOrDefault<ComplexType>("");
+
+            Assert.That(actual, Is.Null);
         }
 
         public class ComplexType

--- a/Moq.Dapper/ObjectExtensions.cs
+++ b/Moq.Dapper/ObjectExtensions.cs
@@ -7,19 +7,13 @@ namespace Moq.Dapper
 {
     static class ObjectExtensions
     {
-        internal static DataTable ToDataTable(this object result, Type resultType)
-        {
-            switch (result)
+        internal static DataTable ToDataTable(this object result, Type resultType) =>
+            result switch
             {
-                case null:
-                    return Array.CreateInstance(resultType, 0).ToDataTable(resultType);
-                case string resultString: // this needs to come before IEnumerable because strings are IEnumerable<char>
-                    return new[] { resultString }.ToDataTable(resultType);
-                case IEnumerable results:
-                    return results.ToDataTable(resultType.GenericTypeArguments.Single());
-                default:
-                    return new[] { result }.ToDataTable(resultType);
-            }
-        }
+                null                => Array.CreateInstance(resultType, 0).ToDataTable(resultType),
+                string resultString => new[] { resultString }.ToDataTable(resultType),
+                IEnumerable results => results.ToDataTable(resultType.GenericTypeArguments.Single()),
+                _                   => new[] { result }.ToDataTable(resultType)
+            };
     }
 }

--- a/Moq.Dapper/ObjectExtensions.cs
+++ b/Moq.Dapper/ObjectExtensions.cs
@@ -13,6 +13,8 @@ namespace Moq.Dapper
             {
                 case null:
                     return Array.CreateInstance(resultType, 0).ToDataTable(resultType);
+                case string resultString: // this needs to come before IEnumerable bccause strings are IEnumerable<char>
+                    return new[] { resultString }.ToDataTable(resultType);
                 case IEnumerable results:
                     return results.ToDataTable(resultType.GenericTypeArguments.Single());
                 default:

--- a/Moq.Dapper/ObjectExtensions.cs
+++ b/Moq.Dapper/ObjectExtensions.cs
@@ -7,9 +7,17 @@ namespace Moq.Dapper
 {
     static class ObjectExtensions
     {
-         internal static DataTable ToDataTable(this object result, Type resultType) =>
-             result is IEnumerable results ?
-             results.ToDataTable(resultType.GenericTypeArguments.Single()) :
-             new[] { result }.ToDataTable(resultType);
+        internal static DataTable ToDataTable(this object result, Type resultType)
+        {
+            switch (result)
+            {
+                case null:
+                    return Array.CreateInstance(resultType, 0).ToDataTable(resultType);
+                case IEnumerable results:
+                    return results.ToDataTable(resultType.GenericTypeArguments.Single());
+                default:
+                    return new[] { result }.ToDataTable(resultType);
+            }
+        }
     }
 }

--- a/Moq.Dapper/ObjectExtensions.cs
+++ b/Moq.Dapper/ObjectExtensions.cs
@@ -13,7 +13,7 @@ namespace Moq.Dapper
             {
                 case null:
                     return Array.CreateInstance(resultType, 0).ToDataTable(resultType);
-                case string resultString: // this needs to come before IEnumerable bccause strings are IEnumerable<char>
+                case string resultString: // this needs to come before IEnumerable because strings are IEnumerable<char>
                     return new[] { resultString }.ToDataTable(resultType);
                 case IEnumerable results:
                     return results.ToDataTable(resultType.GenericTypeArguments.Single());


### PR DESCRIPTION
This pull request adds support for:

- returning strings from first/singleordefault queries
- add null returns for reference types for first/singleordefault queries

It does this by modifying the ObjectExtensions to use a switch statement that provides matches for null values and strings before the existing behaviors. Null values use an empty array to convert to the DataTable, while strings use the existing behavior for non-IEnumerables. Since this check needs to happen before the test for the result being IEnumerable, there's a slight duplication that has been documented.