### PR TITLE
query ValueTuple

### DIFF
--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -48,16 +48,15 @@ namespace Moq.Dapper.Test
         [Test]
         public void QueryAsyncValueTuple()
         {
-            // arrange
             var connection = new Mock<DbConnection>();
+            
             var expected = new List<(int, string)> { (123, "Jack") };
+            
             connection.SetupDapperAsync(c => c.QueryAsync<(int, string)>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IDbTransaction>(), It.IsAny<int?>(), It.IsAny<CommandType?>()))
-                .ReturnsAsync(expected);
+                      .ReturnsAsync(expected);
 
-            // act
-            var actual = connection.Object.QueryAsync<(int, string)>("select id, name from users;").GetAwaiter().GetResult();
+            var actual = connection.Object.QueryAsync<(int, string)>("").GetAwaiter().GetResult();
 
-            // assert
             Assert.AreEqual(expected, actual);
         }
 

--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -46,6 +46,22 @@ namespace Moq.Dapper.Test
         }
 
         [Test]
+        public void QueryAsyncValueTuple()
+        {
+            // arrange
+            var connection = new Mock<DbConnection>();
+            var expected = new List<(int, string)> { (123, "Jack") };
+            connection.SetupDapperAsync(c => c.QueryAsync<(int, string)>(It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IDbTransaction>(), It.IsAny<int?>(), It.IsAny<CommandType?>()))
+                .ReturnsAsync(expected);
+
+            // act
+            var actual = connection.Object.QueryAsync<(int, string)>("select id, name from users;").GetAwaiter().GetResult();
+
+            // assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void QuerySingleAsyncGeneric()
         {
             var connection = new Mock<DbConnection>();

--- a/Moq.Dapper/EnumerableExtensions.cs
+++ b/Moq.Dapper/EnumerableExtensions.cs
@@ -23,13 +23,16 @@ namespace Moq.Dapper
             else if (tableType.IsValueTupleType())
             {
                 var fields = tableType.GetFields();
+                
                 var columns = fields.Select(x => new DataColumn(x.Name, x.FieldType)).ToArray();
+                
                 dataTable.Columns.AddRange(columns);
-                var valuesFactory = fields.Select(info => (Func<object, object>)info.GetValue);
+                
+                var valuesFactory = 
+                    fields.Select(info => (Func<object, object>)info.GetValue).ToList();
+                
                 foreach (var element in results)
-                {
                     dataTable.Rows.Add(valuesFactory.Select(getValue => getValue(element)).ToArray());
-                }
             }
             else
             {
@@ -77,7 +80,7 @@ namespace Moq.Dapper
             return dataTable;
         }
 
-        private static readonly HashSet<Type> ValueTupleTypes = new HashSet<Type>(new Type[]
+        static readonly HashSet<Type> ValueTupleTypes = new(new[]
         {
             typeof(ValueTuple<>),
             typeof(ValueTuple<,>),
@@ -89,6 +92,11 @@ namespace Moq.Dapper
             typeof(ValueTuple<,,,,,,,>)
         });
 
-        private static bool IsValueTupleType(this Type type) => type.IsGenericType && ValueTupleTypes.Contains(type.GetGenericTypeDefinition());
+        static bool IsValueTupleType(this Type type)
+        {
+            var genericTypeDefinition = type.GetGenericTypeDefinition();
+            return type.IsGenericType &&
+                   ValueTupleTypes.Contains(genericTypeDefinition);
+        }
     }
 }


### PR DESCRIPTION
we can now query `ValueTuple<>`. this PR might fix #82 